### PR TITLE
Append stderr to log and provision ssd filesystem

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -4,6 +4,19 @@ mkdir -p /tmp/provision
 cd /tmp/provision
 
 #--------------------------------------------------------------------------------
+# Provision ephemeral SSD if available.  
+#--------------------------------------------------------------------------------
+
+# Look for 2 SSDs and mount them as RAID 0 if available
+lsblk | grep nvme1n1
+if [ $? -eq 0 ]; then
+   yes | sudo mdadm --create /dev/md0 --level=0 -c256 --raid-devices=2 /dev/nvme0n1 /dev/nvme1n1
+   mkfs -E nodiscard -t ext4 /dev/md0
+   mount -t ext4 -o noatime /dev/md0 /mnt
+   chmod 777 /mnt
+fi
+
+#--------------------------------------------------------------------------------
 # install dependencies
 #--------------------------------------------------------------------------------
 

--- a/s3/run.sh
+++ b/s3/run.sh
@@ -23,4 +23,4 @@ GC_FLAGS="-verbosegc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDate
 # use "latest" (alphasort - not ideal) jarfile in case of > 1.  Should only be one, as "provision.sh" copies only one to local machine
 JARFILE=$(ls -1 ${BASE_DIR}/s3bench-*-jar-with-dependencies.jar | tail -1)
 
-java $LOG_FLAGS $HEAP_FLAGS $GC_FLAGS -jar $JARFILE "$@" > /var/log/s3bench/s3bench.log
+java $LOG_FLAGS $HEAP_FLAGS $GC_FLAGS -jar $JARFILE "$@" &> /var/log/s3bench/s3bench.log


### PR DESCRIPTION
* Append stderr to `/var/log/s3bench/s3bench.log`
* `scalyr-aws` was adding ephemeral ssd device mappings but not creating a filesystem on the ssd or mounting the ssd file.  Added functionality to `provision.sh` to look for 2 ssd, configure them in RAID 0, and mount them under `mnt`.  This is the same as the ssd configuration for the prod-log servers.